### PR TITLE
Recipe handles both temperature and polarization at once

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -99,3 +99,6 @@ ENV/
 
 # mypy
 .mypy_cache/
+
+# pylint
+pylintrc

--- a/dustbuster/pysm_helpers.py
+++ b/dustbuster/pysm_helpers.py
@@ -3,7 +3,6 @@
 import sys
 import numpy as np
 import pysm
-import inspect
 
 def get_sky(nside, tag='c1d0s0'):
     """ Get a pre-defined PySM sky
@@ -100,8 +99,8 @@ def _dict_instrument_planck_P(nside):
 def _dict_instrument_litebird(nside):
     return {
 	'frequencies': np.array([40.0, 50.0, 60.0, 68.4, 78.0, 88.5, 100.0, 118.9, 140.0, 166.0, 195.0, 234.9, 280.0, 337.4, 402.1]),
-        'sens_I': np.array([42.4,  25.8,  20.1,  15.6, 12.5, 10.1,  11.8, 9.5, 7.6,   6.7, 5.1,   6.3, 10.1,  10.1,  19.1]) / 1.41,
-        'sens_P': np.array([42.4,  25.8,  20.1,  15.6, 12.5, 10.1,  11.8, 9.5, 7.6,   6.7, 5.1,   6.3, 10.1,  10.1,  19.1]),
+        'sens_I': np.array([42.4, 25.8, 20.1, 15.6, 12.5, 10.1, 11.8, 9.5, 7.6,  6.7, 5.1,  6.3, 10.1, 10.1, 19.1]) / 1.41,
+        'sens_P': np.array([42.4, 25.8, 20.1, 15.6, 12.5, 10.1, 11.8, 9.5, 7.6,  6.7, 5.1,  6.3, 10.1, 10.1, 19.1]),
         'beams': np.array([60, 56, 48, 43, 39, 35, 29, 25, 23, 21, 20, 19, 24, 20, 17]),
         'nside': nside,
         'add_noise': True,
@@ -110,5 +109,5 @@ def _dict_instrument_litebird(nside):
         'output_units': 'uK_CMB',
         'output_directory': '/dev/null',
         'output_prefix': 'planck',
-        'use_smoothing': True,
+        'use_smoothing': False,
     }

--- a/example/separation.ipynb
+++ b/example/separation.ipynb
@@ -19,8 +19,7 @@
    "cell_type": "code",
    "execution_count": 1,
    "metadata": {},
-   "outputs": [
-   ],
+   "outputs": [],
    "source": [
     "%load_ext autoreload\n",
     "%autoreload 2\n",
@@ -34,7 +33,7 @@
     "nside = 32\n",
     "sky = get_sky(nside, 'c1d0s0')\n",
     "instrument = get_instrument(nside, 'litebird')\n",
-    "freq_maps = instrument.observe(sky, write_outputs=False)[0][:, 1:, :] # Keep only polarization"
+    "freq_maps = instrument.observe(sky, write_outputs=False)[0]"
    ]
   },
   {
@@ -69,11 +68,10 @@
    "metadata": {
     "scrolled": true
    },
-   "outputs": [
-   ],
+   "outputs": [],
    "source": [
     "from dustbuster.separation_recipies import basic_comp_sep\n",
-    "res = basic_comp_sep(components, instrument, freq_maps)"
+    "res = basic_comp_sep([components, components], instrument, freq_maps)"
    ]
   },
   {


### PR DESCRIPTION
- `basic_comp_sep` can take two lists of components: one for temperature and one for polarization
- `comp_of_dB` is now the whole indexing object for `s`, not just the slice of the "component" dimension